### PR TITLE
ci: Add linter to the project CI 

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,4 +13,8 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version-file: './go.mod'
+      - name: Install golangci-lint
+        run: |
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $HOME/bin
+          echo "$HOME/bin" >> $GITHUB_PATH
       - run: make check-suite

--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,4 @@ config.*.yaml
 # Helm chart values ignorance
 values.*.yaml
 !values.yaml
+.history/

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,9 @@ test:
 	go test ./...
 
 lint:
-	golint ./...
+	golangci-lint run ./...
 
-check-suite: test
+check-suite: test lint
+
+install-lint:
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest


### PR DESCRIPTION
switch to golangci-lint (golint deprecated)
-  Replace golint with golangci-lint in Makefile
- Install and run golangci-lint in CI workflow
- Refs: #3 