### PR TITLE
feat: add proksi-redis shadow-testing redis proxy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,12 @@ build-http:
 build-linux-http:
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -a -installsuffix cgo -o proksi-http ./http
 
+build-redis:
+	CGO_ENABLED=0 go build -a -installsuffix cgo -o proksi-redis ./redis
+
+build-linux-redis:
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -a -installsuffix cgo -o proksi-redis ./redis
+
 test:
 	go test ./...
 

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/elastic/go-elasticsearch/v8 v8.3.0
 	github.com/knadh/koanf v1.4.3
 	github.com/prometheus/client_golang v1.11.1
+	github.com/tidwall/redcon v1.6.4
 	github.com/tidwall/sjson v1.2.5
 	go.uber.org/zap v1.22.0
 )
@@ -24,6 +25,7 @@ require (
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.26.0 // indirect
 	github.com/prometheus/procfs v0.6.0 // indirect
+	github.com/tidwall/btree v1.1.0 // indirect
 	github.com/tidwall/gjson v1.14.3 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -246,6 +246,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/tidwall/btree v1.1.0 h1:5P+9WU8ui5uhmcg3SoPyTwoI0mVyZ1nps7YQzTZFkYM=
+github.com/tidwall/btree v1.1.0/go.mod h1:TzIRzen6yHbibdSfK6t8QimqbUnoxUSrZfeW7Uob0q4=
 github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/gjson v1.14.3 h1:9jvXn7olKEHU1S9vwoMGliaT8jq1vJ7IH/n9zD9Dnlw=
 github.com/tidwall/gjson v1.14.3/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
@@ -254,6 +256,8 @@ github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JT
 github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 github.com/tidwall/pretty v1.2.1 h1:qjsOFOWWQl+N3RsoF5/ssm1pHmJJwhjlSbZ51I6wMl4=
 github.com/tidwall/pretty v1.2.1/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
+github.com/tidwall/redcon v1.6.4 h1:e1xUcbfVZukGrWJo7jAXN+saw6UnPYrCZYVGXaoafXw=
+github.com/tidwall/redcon v1.6.4/go.mod h1:rKGKSGkNdBKCjAjC2jDwvCnT+NYCpNqy0aGq4YKJSKQ=
 github.com/tidwall/sjson v1.2.5 h1:kLy8mja+1c9jlljvWTlSazM7cKDRfJuR/bOJhcY5NcY=
 github.com/tidwall/sjson v1.2.5/go.mod h1:Fvgq9kS/6ociJEDnK0Fk1cpYF4FIW6ZF7LAe+6jwd28=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/internal/config/redis.go
+++ b/internal/config/redis.go
@@ -1,0 +1,73 @@
+package config
+
+import (
+	"github.com/knadh/koanf/parsers/yaml"
+	"github.com/knadh/koanf/providers/file"
+	"github.com/knadh/koanf/providers/structs"
+	"go.uber.org/zap"
+
+	"github.com/snapp-incubator/proksi/internal/logging"
+)
+
+var (
+	// Redis is the config for Proksi Redis
+	Redis *RedisConfig
+)
+
+var defaultRedis = RedisConfig{
+	Bind: "0.0.0.0:6380",
+	Metrics: metric{
+		Enabled: true,
+		Bind:    "0.0.0.0:9001",
+	},
+	Upstreams: struct {
+		Main redisUpstream `koanf:"main"`
+		Test redisUpstream `koanf:"test"`
+	}{
+		Main: redisUpstream{Address: "127.0.0.1:6379"},
+		Test: redisUpstream{Address: "127.0.0.1:6380"},
+	},
+	Worker: worker{
+		Count:     50,
+		QueueSize: 2048,
+	},
+}
+
+// RedisConfig represent config of the Proksi Redis.
+type RedisConfig struct {
+	Bind      string `koanf:"bind"`
+	Metrics   metric `koanf:"metrics"`
+	Upstreams struct {
+		Main redisUpstream `koanf:"main"`
+		Test redisUpstream `koanf:"test"`
+	} `koanf:"upstreams"`
+	Worker worker `koanf:"worker"`
+}
+
+type redisUpstream struct {
+	Address string `koanf:"address"`
+}
+
+// LoadRedis function will load the file located in path and return the parsed config for ProksiRedis. This function will panic on errors
+func LoadRedis(path string) *RedisConfig {
+	// Load default config in the beginning
+	err := k.Load(structs.Provider(defaultRedis, "koanf"), nil)
+	if err != nil {
+		logging.L.Fatal("error in loading the default config", zap.Error(err))
+	}
+
+	// Load YAML config and merge into the previously loaded config.
+	err = k.Load(file.Provider(path), yaml.Parser())
+	if err != nil {
+		logging.L.Fatal("error in loading the config file", zap.Error(err))
+	}
+
+	var c RedisConfig
+	err = k.Unmarshal("", &c)
+	if err != nil {
+		logging.L.Fatal("error in unmarshalling the config file", zap.Error(err))
+	}
+
+	Redis = &c
+	return &c
+}

--- a/internal/metrics/redis.go
+++ b/internal/metrics/redis.go
@@ -1,0 +1,46 @@
+package metrics
+
+import (
+	"net/http"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"go.uber.org/zap"
+
+	"github.com/snapp-incubator/proksi/internal/logging"
+)
+
+var (
+	// RedisCmdCounter is the total number of redis commands proxied, partitioned by
+	// the command name and the upstream (main_upstream/test_upstream).
+	RedisCmdCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "proksi",
+		Subsystem: "redis",
+		Name:      "command_count",
+		Help:      "Redis command count",
+	}, []string{"command", "upstream"})
+
+	// RedisCmdDuration is the duration of each redis command proxied to an upstream.
+	RedisCmdDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: "proksi",
+		Subsystem: "redis",
+		Name:      "command_duration",
+		Help:      "Duration of each redis command",
+		Buckets:   buckets,
+	}, []string{"command", "upstream"})
+)
+
+// InitializeRedis initialize the metrics server for Proksi Redis.
+func InitializeRedis(bind string) {
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", promhttp.Handler())
+
+	srv := http.Server{
+		Addr:    bind,
+		Handler: mux,
+	}
+	if err := srv.ListenAndServe(); err != http.ErrServerClosed {
+		logging.L.Fatal("Error in HTTP server ListenAndServe", zap.Error(err))
+	}
+}

--- a/redis/config.example.yaml
+++ b/redis/config.example.yaml
@@ -1,0 +1,23 @@
+# Redis server bind address to serve Proksi
+bind: "0.0.0.0:6380"
+
+# Config of exposing Prometheus metrics
+metrics:
+  enabled: true
+  bind: "0.0.0.0:9001"
+
+# List of upstreams to proxy the command to them
+upstreams:
+  # main is the upstream that we are sure about its behavior and its response will be the criterion.
+  # The response of the command will be the main upstream response.
+  main:
+    address: "127.0.0.1:6379"
+  # test is the upstream that we want to test its behavior.
+  # The commands will be sent to the test upstream asynchronously and its response will be discarded.
+  test:
+    address: "127.0.0.1:6380"
+
+# Worker pool configurations
+worker:
+  count: 50               # Number of go-routines of the pool
+  queue_size: 2048        # Size of the queue (buffered channel size)

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -1,0 +1,351 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"io"
+	"net"
+	"os"
+	"os/signal"
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/tidwall/redcon"
+	"go.uber.org/zap"
+
+	"github.com/snapp-incubator/proksi/internal/config"
+	"github.com/snapp-incubator/proksi/internal/logging"
+	"github.com/snapp-incubator/proksi/internal/metrics"
+)
+
+var (
+	help       bool   // Indicates whether to show the help or not
+	configPath string // Path of config file
+)
+
+func init() {
+	flag.BoolVar(&help, "help", false, "Show help")
+	flag.StringVar(&configPath, "config", "", "The path of config file")
+}
+
+func main() {
+	// Parse the terminal flags
+	flag.Parse()
+
+	// Usage Demo
+	if help {
+		flag.Usage()
+		return
+	}
+
+	c := config.LoadRedis(configPath)
+
+	if c.Upstreams.Main.Address == "" {
+		logging.L.Fatal("Main upstream backend can not be empty.")
+	}
+
+	if c.Upstreams.Test.Address == "" {
+		logging.L.Fatal("Test upstream backend can not be empty.")
+	}
+
+	mainClient, err := newUpstreamClient(c.Upstreams.Main.Address)
+	if err != nil {
+		logging.L.Fatal("Error in connecting to the main upstream", zap.Error(err))
+	}
+	defer mainClient.close()
+
+	testClient, err := newUpstreamClient(c.Upstreams.Test.Address)
+	if err != nil {
+		logging.L.Fatal("Error in connecting to the test upstream", zap.Error(err))
+	}
+	defer testClient.close()
+
+	jobs := make(chan Job, c.Worker.QueueSize)
+
+	for i := uint(0); i < c.Worker.Count; i++ {
+		go func() {
+			for job := range jobs {
+				job.Do()
+			}
+		}()
+	}
+
+	s := &server{
+		job:        jobs,
+		mainClient: mainClient,
+		testClient: testClient,
+	}
+
+	srv := redcon.NewServer(c.Bind, s.handle, accept, closed)
+
+	go func() {
+		logging.L.Info("Starting Redis server",
+			zap.String("address", c.Bind),
+			zap.String("main_upstream", c.Upstreams.Main.Address),
+			zap.String("test_upstream", c.Upstreams.Test.Address),
+		)
+		if err := srv.ListenAndServe(); err != nil {
+			logging.L.Fatal("Redis server ListenAndServe Error", zap.Error(err))
+		}
+	}()
+
+	if c.Metrics.Enabled {
+		go metrics.InitializeRedis(c.Metrics.Bind)
+	}
+
+	sigint := make(chan os.Signal, 1)
+	signal.Notify(sigint, os.Interrupt)
+	<-sigint
+
+	logging.L.Debug("Closing Redis server")
+	if err := srv.Close(); err != nil {
+		logging.L.Error("Error in shutting down the Redis server", zap.Error(err))
+	}
+	close(jobs)
+
+	logging.L.Info("Redis server is shut down")
+}
+
+type server struct {
+	job        chan Job
+	mainClient *upstreamClient
+	testClient *upstreamClient
+}
+
+// handle is the redcon command handler. It forwards the command to the main upstream
+// synchronously and writes the raw reply back to the client. It then enqueues the
+// command to the test upstream for asynchronous execution.
+func (s *server) handle(conn redcon.Conn, cmd redcon.Command) {
+	command := commandName(cmd.Args)
+
+	loggingFieldsWithError := func(err error) []zap.Field {
+		return []zap.Field{
+			zap.String("command", command),
+			zap.String("remote_addr", conn.RemoteAddr()),
+			zap.Error(err),
+		}
+	}
+
+	// Forward the command to the main upstream synchronously.
+	timer := prometheus.NewTimer(metrics.RedisCmdDuration.WithLabelValues(command, "main_upstream"))
+	reply, err := s.mainClient.send(cmd.Raw)
+	timer.ObserveDuration()
+	if err != nil {
+		metrics.RedisCmdCounter.WithLabelValues("client_error", "main_upstream").Inc()
+		logging.L.Error("error in sending the command to the main upstream", loggingFieldsWithError(err)...)
+		conn.WriteError("ERR main upstream error: " + err.Error())
+		return
+	}
+
+	metrics.RedisCmdCounter.WithLabelValues(command, "main_upstream").Inc()
+
+	// Write the raw reply back to the client. The reply is the exact RESP bytes
+	// received from the main upstream, preserving the reply type (status, error,
+	// integer, bulk, array, ...).
+	conn.WriteRaw(reply)
+
+	// Enqueue the command to the test upstream for asynchronous execution.
+	select {
+	case s.job <- &upstreamTestJob{
+		command: command,
+		raw:     cmd.Raw,
+		client:  s.testClient,
+		logFields: func(err error) []zap.Field {
+			return loggingFieldsWithError(err)
+		},
+	}:
+	default:
+		logging.L.Warn("dropping test upstream job due to full queue",
+			zap.String("command", command),
+			zap.String("remote_addr", conn.RemoteAddr()),
+		)
+	}
+}
+
+// Job is a unit of work executed by the worker pool.
+type Job interface {
+	Do()
+}
+
+// upstreamTestJob forwards a command to the test upstream asynchronously and discards
+// the reply. Errors are logged but never returned to the client.
+type upstreamTestJob struct {
+	command   string
+	raw       []byte
+	client    *upstreamClient
+	logFields func(err error) []zap.Field
+}
+
+func (j *upstreamTestJob) Do() {
+	timer := prometheus.NewTimer(metrics.RedisCmdDuration.WithLabelValues(j.command, "test_upstream"))
+	_, err := j.client.send(j.raw)
+	timer.ObserveDuration()
+	if err != nil {
+		metrics.RedisCmdCounter.WithLabelValues("client_error", "test_upstream").Inc()
+		logging.L.Error("error in sending the command to the test upstream", j.logFields(err)...)
+		return
+	}
+
+	metrics.RedisCmdCounter.WithLabelValues(j.command, "test_upstream").Inc()
+}
+
+// accept is called to accept or deny the connection.
+func accept(conn redcon.Conn) bool {
+	return true
+}
+
+// closed is called when the connection has been closed.
+func closed(conn redcon.Conn, err error) {
+	if err != nil && !errors.Is(err, io.EOF) {
+		logging.L.Debug("connection closed with error",
+			zap.String("remote_addr", conn.RemoteAddr()),
+			zap.Error(err),
+		)
+	}
+}
+
+// commandName returns the lowercased name of the command (the first argument).
+func commandName(args [][]byte) string {
+	if len(args) == 0 {
+		return ""
+	}
+	name := make([]byte, len(args[0]))
+	for i := 0; i < len(args[0]); i++ {
+		c := args[0][i]
+		if c >= 'A' && c <= 'Z' {
+			c += 'a' - 'A'
+		}
+		name[i] = c
+	}
+	return string(name)
+}
+
+// readTimeout is the maximum time to wait for a single upstream reply.
+const readTimeout = 30 * time.Second
+
+// upstreamClient is a pooled client for a single redis upstream. It maintains a pool
+// of idle connections and dials new ones on demand.
+type upstreamClient struct {
+	addr    string
+	idle    chan net.Conn
+	closed  bool
+	closeMu sync.Mutex
+}
+
+// newUpstreamClient creates a new pooled upstream client and verifies the upstream is
+// reachable by dialing a probe connection.
+func newUpstreamClient(addr string) (*upstreamClient, error) {
+	c := &upstreamClient{
+		addr: addr,
+		idle: make(chan net.Conn, 32),
+	}
+
+	conn, err := c.dial()
+	if err != nil {
+		return nil, err
+	}
+	c.idle <- conn
+
+	return c, nil
+}
+
+func (c *upstreamClient) dial() (net.Conn, error) {
+	c.closeMu.Lock()
+	defer c.closeMu.Unlock()
+	if c.closed {
+		return nil, errors.New("upstream client is closed")
+	}
+	return net.DialTimeout("tcp", c.addr, 5*time.Second)
+}
+
+// send writes a raw RESP command to the upstream and reads back one complete raw RESP
+// reply. The connection is returned to the pool on success.
+func (c *upstreamClient) send(raw []byte) ([]byte, error) {
+	conn, err := c.acquire()
+	if err != nil {
+		return nil, err
+	}
+
+	reply, err := roundTrip(conn, raw)
+	if err != nil {
+		// The connection may be in a bad state; discard it.
+		_ = conn.Close()
+		return nil, err
+	}
+
+	c.release(conn)
+	return reply, nil
+}
+
+func (c *upstreamClient) acquire() (net.Conn, error) {
+	select {
+	case conn := <-c.idle:
+		return conn, nil
+	default:
+		return c.dial()
+	}
+}
+
+func (c *upstreamClient) release(conn net.Conn) {
+	select {
+	case c.idle <- conn:
+	default:
+		_ = conn.Close()
+	}
+}
+
+func (c *upstreamClient) close() {
+	c.closeMu.Lock()
+	c.closed = true
+	c.closeMu.Unlock()
+	close(c.idle)
+	for conn := range c.idle {
+		_ = conn.Close()
+	}
+}
+
+// roundTrip writes a raw RESP command to conn and reads back one complete raw RESP reply.
+// It uses redcon.ReadNextRESP to frame the reply, reading more bytes from the socket
+// until a full reply is available.
+func roundTrip(conn net.Conn, raw []byte) ([]byte, error) {
+	if err := conn.SetDeadline(time.Now().Add(readTimeout)); err != nil {
+		return nil, err
+	}
+
+	if _, err := conn.Write(raw); err != nil {
+		return nil, err
+	}
+
+	// Read directly from the connection into a growing buffer and frame the reply
+	// with redcon.ReadNextRESP. Reading raw (rather than through a bufio.Reader) keeps
+	// the pooled connection free of leftover buffered state between commands.
+	var buf []byte
+	scratch := make([]byte, 4096)
+
+	for {
+		n, resp := redcon.ReadNextRESP(buf)
+		if n > 0 {
+			// A complete reply has been parsed; return its raw bytes. Copy it so the
+			// scratch buffer can be reused for the next command.
+			out := make([]byte, n)
+			copy(out, buf[:n])
+			return out, nil
+		}
+		_ = resp // resp is zero-value when n == 0 (incomplete).
+
+		nn, err := conn.Read(scratch)
+		if nn > 0 {
+			buf = append(buf, scratch[:nn]...)
+			// Try framing again before handling a read error so a final short read
+			// that completes the reply is not reported as an error.
+			continue
+		}
+		if err != nil {
+			if err == io.EOF && len(buf) > 0 {
+				return nil, errors.New("unexpected EOF while reading upstream reply")
+			}
+			return nil, err
+		}
+	}
+}

--- a/redis/redis_test.go
+++ b/redis/redis_test.go
@@ -1,0 +1,242 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"net"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/tidwall/redcon"
+)
+
+// fakeUpstream is a minimal redis upstream backed by a redcon server. It records every
+// command it receives and replies with a canned response per command.
+type fakeUpstream struct {
+	addr     string
+	server   *redcon.Server
+	mu       sync.Mutex
+	received [][]byte
+	reply    func(cmd redcon.Command) []byte
+}
+
+func newFakeUpstream(reply func(cmd redcon.Command) []byte) (*fakeUpstream, error) {
+	u := &fakeUpstream{reply: reply}
+
+	srv := redcon.NewServer("127.0.0.1:0",
+		func(conn redcon.Conn, cmd redcon.Command) {
+			u.mu.Lock()
+			// Copy raw so it survives after redcon reuses its buffers (the live server
+			// already copies, but be defensive).
+			raw := append([]byte(nil), cmd.Raw...)
+			u.received = append(u.received, raw)
+			u.mu.Unlock()
+
+			conn.WriteRaw(reply(cmd))
+		},
+		func(redcon.Conn) bool { return true },
+		func(redcon.Conn, error) {},
+	)
+	u.server = srv
+
+	signal := make(chan error, 1)
+	go func() { _ = srv.ListenServeAndSignal(signal) }()
+	if err := <-signal; err != nil {
+		return nil, fmt.Errorf("fake upstream failed to listen: %v", err)
+	}
+	u.addr = srv.Addr().String()
+
+	// Wait until the listener accepts connections.
+	for i := 0; i < 50; i++ {
+		c, err := net.DialTimeout("tcp", u.addr, 50*time.Millisecond)
+		if err == nil {
+			_ = c.Close()
+			return u, nil
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	return nil, fmt.Errorf("fake upstream %s did not come up", u.addr)
+}
+
+func (u *fakeUpstream) stop() {
+	_ = u.server.Close()
+}
+
+func (u *fakeUpstream) count() int {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	return len(u.received)
+}
+
+// respClient is a minimal raw RESP client used to drive commands through the proxy.
+type respClient struct {
+	conn net.Conn
+}
+
+func dialResp(addr string) (*respClient, error) {
+	c, err := net.DialTimeout("tcp", addr, 2*time.Second)
+	if err != nil {
+		return nil, err
+	}
+	return &respClient{conn: c}, nil
+}
+
+func (c *respClient) close() { _ = c.conn.Close() }
+
+// do writes a command (as RESP array of bulk strings) and reads back one raw RESP reply.
+func (c *respClient) do(args ...string) ([]byte, error) {
+	var wr redcon.Writer
+	wr.WriteArray(len(args))
+	for _, a := range args {
+		wr.WriteBulkString(a)
+	}
+	if _, err := c.conn.Write(wr.Buffer()); err != nil {
+		return nil, err
+	}
+
+	_ = c.conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	buf := make([]byte, 0, 256)
+	scratch := make([]byte, 4096)
+	for {
+		n, _ := redcon.ReadNextRESP(buf)
+		if n > 0 {
+			out := make([]byte, n)
+			copy(out, buf[:n])
+			return out, nil
+		}
+		nn, err := c.conn.Read(scratch)
+		if nn > 0 {
+			buf = append(buf, scratch[:nn]...)
+			continue
+		}
+		if err != nil {
+			return nil, err
+		}
+	}
+}
+
+// TestProxyEndToEnd verifies that:
+//   - the proxy returns the main upstream's raw reply to the client verbatim;
+//   - the test upstream receives the same command asynchronously;
+//   - reply types (status, integer, bulk, array, error, nil) are preserved.
+func TestProxyEndToEnd(t *testing.T) {
+	// Main upstream: replies depend on the command to exercise every RESP type.
+	main, err := newFakeUpstream(func(cmd redcon.Command) []byte {
+		switch strings.ToLower(string(cmd.Args[0])) {
+		case "ping":
+			return []byte("+PONG\r\n") // status
+		case "incr":
+			return []byte(":42\r\n") // integer
+		case "get":
+			return []byte("$5\r\nhello\r\n") // bulk
+		case "hgetall":
+			return []byte("*4\r\n$3\r\nfoo\r\n$3\r\nbar\r\n$3\r\nbaz\r\n$3\r\nqux\r\n") // array
+		case "del":
+			return []byte("$-1\r\n") // nil bulk
+		case "fail":
+			return []byte("-ERR boom\r\n") // error
+		default:
+			return []byte("+OK\r\n")
+		}
+	})
+	if err != nil {
+		t.Fatalf("start main upstream: %v", err)
+	}
+	defer main.stop()
+
+	// Test upstream: records the command, replies OK (reply is discarded by the proxy).
+	test, err := newFakeUpstream(func(cmd redcon.Command) []byte {
+		return []byte("+OK\r\n")
+	})
+	if err != nil {
+		t.Fatalf("start test upstream: %v", err)
+	}
+	defer test.stop()
+
+	mainClient, err := newUpstreamClient(main.addr)
+	if err != nil {
+		t.Fatalf("main upstream client: %v", err)
+	}
+	defer mainClient.close()
+
+	testClient, err := newUpstreamClient(test.addr)
+	if err != nil {
+		t.Fatalf("test upstream client: %v", err)
+	}
+	defer testClient.close()
+
+	jobs := make(chan Job, 256)
+	for i := 0; i < 8; i++ {
+		go func() {
+			for job := range jobs {
+				job.Do()
+			}
+		}()
+	}
+	defer close(jobs)
+
+	s := &server{job: jobs, mainClient: mainClient, testClient: testClient}
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	proxyAddr := ln.Addr().String()
+	srv := redcon.NewServer(proxyAddr, s.handle, accept, closed)
+	go func() { _ = srv.Serve(ln) }()
+	defer srv.Close()
+
+	// Wait for the proxy to accept connections.
+	if c, err := net.DialTimeout("tcp", proxyAddr, 1*time.Second); err == nil {
+		_ = c.Close()
+	} else {
+		t.Fatalf("proxy did not come up: %v", err)
+	}
+
+	cli, err := dialResp(proxyAddr)
+	if err != nil {
+		t.Fatalf("dial proxy: %v", err)
+	}
+	defer cli.close()
+
+	cases := []struct {
+		name string
+		args []string
+		want []byte
+	}{
+		{"status", []string{"PING"}, []byte("+PONG\r\n")},
+		{"integer", []string{"INCR", "counter"}, []byte(":42\r\n")},
+		{"bulk", []string{"GET", "k"}, []byte("$5\r\nhello\r\n")},
+		{"array", []string{"HGETALL", "h"}, []byte("*4\r\n$3\r\nfoo\r\n$3\r\nbar\r\n$3\r\nbaz\r\n$3\r\nqux\r\n")},
+		{"nil", []string{"DEL", "missing"}, []byte("$-1\r\n")},
+		{"error", []string{"FAIL"}, []byte("-ERR boom\r\n")},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := cli.do(tc.args...)
+			if err != nil {
+				t.Fatalf("do %v: %v", tc.args, err)
+			}
+			if !bytes.Equal(got, tc.want) {
+				t.Fatalf("reply mismatch\ngot:  %q\nwant: %q", got, tc.want)
+			}
+		})
+	}
+
+	// Every command (including the error and nil cases) must have been mirrored to the
+	// test upstream. The test path is async; poll until the count matches.
+	wantCount := len(cases)
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if test.count() >= wantCount {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if got := test.count(); got != wantCount {
+		t.Fatalf("test upstream received %d commands, want %d", got, wantCount)
+	}
+}


### PR DESCRIPTION
Proksi Redis is a single-binary redis server (built on redcon) that forwards each inbound command to a main upstream synchronously and returns its raw RESP reply to the client, while mirroring the command to a test upstream asynchronously via a worker pool for shadow testing.

- redis/: package main entry point with redcon server, pooled raw RESP upstream clients (transparent passthrough, no reply-type loss), worker pool for async test-upstream execution, graceful shutdown on SIGINT.
- internal/config/redis.go: RedisConfig + LoadRedis mirroring the HTTP config structure (bind, metrics, upstreams.main/test, worker).
- internal/metrics/redis.go: Prometheus command counter + duration histogram under proksi/redis namespace, /metrics server.
- redis/config.example.yaml: documented sample config.
- Makefile: build-redis / build-linux-redis targets.
- go.mod: add github.com/tidwall/redcon v1.6.4.

The transparent raw RESP passthrough preserves every reply type (status, integer, bulk, array, null, error) by forwarding raw bytes rather than re-encoding parsed values. Covered by redis/redis_test.go end-to-end.